### PR TITLE
Update cascading.md

### DIFF
--- a/doc/tutorials/cascading.md
+++ b/doc/tutorials/cascading.md
@@ -1,8 +1,8 @@
-## Order of Namespaces
+# Cascading Lookups
 
-This tutorial assumes that you know what [namespaces](/doc/tutorials/namespaces.md) are. We will only be talking about [cascading lookup](/doc/help/elektra-cascading.md) here.
+This tutorial assumes that you are already familiar with [namespaces](/doc/tutorials/namespaces.md). This tutorial will only explain [cascading lookup](/doc/help/elektra-cascading.md).
 
-When Elektra looks up a key, the namespaces are searched in this order:
+When Elektra looks up a _cascading key_ (i.e. key names without a namespace and a leading slash `/`, the namespaces are searched in the following order:
 
  * [spec](https://github.com/ElektraInitiative/libelektra/blob/master/doc/help/elektra-namespaces.md#spec) (contains metadata, e.g. to modify elektra lookup behaviour)
  * [proc](https://github.com/ElektraInitiative/libelektra/blob/master/doc/help/elektra-namespaces.md#proc) (process-related information)
@@ -10,15 +10,15 @@ When Elektra looks up a key, the namespaces are searched in this order:
  * [user](https://github.com/ElektraInitiative/libelektra/blob/master/doc/help/elektra-namespaces.md#user) (user configuration)
  * [system](https://github.com/ElektraInitiative/libelektra/blob/master/doc/help/elektra-namespaces.md#system) (system configuration)
 
-Looking at this order, we can see that if a configuration option is specified by the user (in the **user** namespace) as well as in the **system** namespace, then the key in the **user** namespace takes precedence over the one in the **system** namespace. If there is no such key in the **user** namespace the key in the **system** namespace acts as a fallback.
+If a key, for example, exists in both **user** and **system** namespace, the key in the **user** namespace takes precedence over the one in the **system** namespace. If there is no such key in the **user** namespace the key in the **system** namespace acts as a fallback.
 
 But lets demonstrate this with an example:
 
-###### Add a Key to the system Namespace
+### Add a Key to the system Namespace
 
-Configuration in the **system** namespace is readable for all users and the same for all users. Therefore this namespace provides a default or fallback configuration.
+Configuration in the **system** namespace is the same for all users. Therefore this namespace provides a default or fallback configuration.
 
-In the default Elektra installation only an administrator can update configuration here:
+With the default Elektra installation only an administrator can update configuration settings within the **system** namespace.
 
 ```sh
 # Backup-and-Restore:/sw/tutorial
@@ -36,9 +36,9 @@ kdb get /sw/tutorial/cascading/#0/current/test
 #> hello world
 ```
 
-###### Add a Key to the user Namespace
+### Add a Key to the user Namespace
 
-A user may now want to override the configuration in **system**, so he sets a key in the **user** namespace:
+A user may now want to override the configuration in **system**, so he/she sets a key in the **user** namespace:
 
 ```sh
 kdb set user/sw/tutorial/cascading/#0/current/test "hello galaxy"
@@ -51,9 +51,9 @@ kdb get /sw/tutorial/cascading/#0/current/test
 
 Note that configuration in the **user** namespace only affects _this_ user. Other users would still get the key from the **system** namespace.
 
-###### Add a Key to the dir Namespace
+### Add a Key to the dir Namespace
 
-The **dir** namespace is associated with a directory. The configuration in the **dir** namespace applies to the associated directory and all its subdirectories.
+The **dir** namespace is associated with a directory. The configuration in the **dir** namespace applies to the **current working directory** and all its subdirectories.
 This is useful if you have project specific settings (e.g. your git configuration or a .htaccess file).
 
 As **dir** precedes the **user** namespace, configuration in **dir** can overwrite user configuration:
@@ -77,22 +77,14 @@ kdb get /sw/tutorial/cascading/#0/current/test
 # hello galaxy
 ```
 
-###### Add a Key to the proc Namespace
+### Add a Key to the proc Namespace
 
-The **proc** namespace is not accessible from the commandline, but only from within applications. So we have to omit an example for this namespace at this point.
+The **proc** namespace is not accessible by the command line tool **kdb**, as it is unique for each running process using Elektra. So we have to omit an example for this namespace at this point.
 [Elektrified](/doc/help/elektra-glossary.md) applications can use this namespace to override configuration from other namespaces internally.
 
-###### Add a Key to the spec Namespace
+### Add a Key to the spec Namespace
 
-Because the **spec** namespace does not contain values of keys but their metadata, Elektra handles the **spec** namespace differently to other namespaces. The following part of the tutorial is dedicated to the impact of the **spec** namespace on cascading lookups.
-
-## Cascading
-
-Cascading triggers actions when, for example, the key isn't found.
-This concept is used for our previous example of using `system` configuration
-when the `user` configuration is not defined. When a key starts with `/`,
-*cascading lookup* will automatically be performed. e.g. using `/test` instead
-of `system/test` will do a cascading lookup.
+The **spec** namespace is used to store metadata about keys and therefore Elektra handles the **spec** namespace differently to other namespaces. The following part of the tutorial is dedicated to the impact of the **spec** namespace on cascading lookups.
 
 
 ## Override Links
@@ -100,70 +92,47 @@ of `system/test` will do a cascading lookup.
 The `spec` namespace is special as it can completely change how the cascading
 lookup works.
 
-For example, in the metadata of the respective `spec`-keys, *override links*
-can be specified to use other keys in favor of the key itself. This way, even
-config from current folders (`dir`) can be overwritten.
+During a cascading lookup for a specific key, the default Elektra behaviour can be changed by a corresponding `spec-key`, i.e. a key in the **spec** namespace **with the same name**.
 
-In the cascading lookup, metadata of `spec`-keys comes in as follows:
+For example, the metadata `override/#0` of the respective `spec-key` 
+can be specified to use a different key in favor of the key itself. This way, we can implement a redirect or symlink like behaviour and therefore even
+config from current folder (`dir` namespace) can be overwritten.
 
- 1. `override/#` keys will be considered
- 2. namespaces specified in the `namespaces/#` keys are considered
- 3. Otherwise, all namespaces will be considered, see [here](/doc/help/elektra-namespaces.md).
- 4. `fallback/#` keys will be considered
- 5. `default` value will be returned
+The cascading lookup will consider the following **metadata keys** of `spec-key`:
 
-**Note:** `override/#` means an array of `override` keys, the array can be filled by
-          setting `#` followed by the position, e.g. `#0`, `#1`, etc.
+ 1. `override/#n` redirect to one of the specified keys
+ 2. `namespaces/#n` specifies which namespaces will be considered and in which order
+ 4. `fallback/#n` if no key was found these keys will act as a fallback
+ 5. `default` defines a default value for the key if none of the keys was found
+
+**Note:** `override/#n`, `namespaces/#n` and `fallback/#n` are Elektra **array keys**. This means, such keys can exist several times, each with a different number for `n`, e.g. `override/#0`, `override/#1`... This way, we can define multiple values for a specific key with a defined order.
 
 As you can see, override links are considered before everything else, which
 makes them really powerful.
 
-To create an override link, first you need to create a key to link the override
-to:
+Consider the following example:
+
+First, we create a target key to demostrate the override link mechanism:
 
 ```sh
 sudo kdb set system/overrides/test "hello override"
 #> Create a new key system/overrides/test with string hello override
 ```
 
-Override links can be defined by adding them to the `override/#` array:
+Override links can be defined by adding them to the `override/#` metadata array key of the correspoding `spec-key`:
 
 ```sh
 sudo kdb setmeta spec/sw/tutorial/cascading/#0/current/test override/#0 /overrides/test
+```
+
+Now when doing a cascading lookup, we get the value of our target key instead of the specified one:
+
+```sh
 kdb get /sw/tutorial/cascading/#0/current/test
 #> hello override
 ```
 
-Furthermore, you can specify a custom order for the namespaces, set fallback
-keys and more. For more information, read the [`elektra-spec` help page](/doc/help/elektra-spec.md).
-
-
-## User Defaults
-
-Override links can also be used to define default values. It's similar to
-defining default values via the `system` namespace, but uses overrides, which
-means it will be preferred over the configuration in the current folder (`dir`).
-
-This means that user defaults overwrite values specified in the `.configuration`
-file we created and mounted earlier in this tutorial.
-
-First you need to create the system default value to link the override to if the
-user hasn't defined it:
-
-```sh
-sudo kdb set system/overrides/test "hello default"
-#> Set string to hello default
-```
-
-Then we can create the link:
-
-```sh
-sudo kdb setmeta spec/sw/tutorial/cascading/#0/current/test override/#0 /overrides/test
-kdb get /sw/tutorial/cascading/#0/current/test
-#> hello default
-```
-
-Now the user overrides the system default:
+As we used a cascading key for our override link (`/overrides/test`) we can use this to allow users to provide their own `overrides/test` keys. If a user sets the `/overrides/test` key, the **user** namespace will be used and therefore the new target for our `/sw/tutorial/cascading/#0/current/test` key will be `user/overrides/test` instead `system/overrides/test`.
 
 ```sh
 kdb set /overrides/test "hello user"
@@ -172,6 +141,10 @@ kdb set /overrides/test "hello user"
 kdb get /sw/tutorial/cascading/#0/current/test
 #> hello user
 ```
+
+Furthermore, you can specify a custom order for the namespaces, set fallback
+keys and more. For more information, read the [`elektra-spec` help page](/doc/help/elektra-spec.md).
+
 
 ## Cleanup
 


### PR DESCRIPTION
- update title to match the content
- simplify explanations in the introduction chapter (hopefully)
- fix heading levels (levels grater than 3 are hard to distinguish from normal text on the libelektra.org site)
- gender fixes
- remove the cascading chapter. Doesn't really add something new and is just confusing.
- rework the override links Section
- merge the user default section with the override links section (its really the same but explained twice)

